### PR TITLE
Reflection-based infrastructure for SDF hierarchy exploration and bounding box rendering implementation.

### DIFF
--- a/entrypoint.go
+++ b/entrypoint.go
@@ -90,6 +90,7 @@ func NewRenderer(anySDF interface{}, opts ...Option) *Renderer {
 	}
 	r.implDimCache = r.impl.Dimensions()
 	r.implState = r.newRendererState()
+	r.implState.ReflectTree = r.impl.ReflectTree() // Compute the reflection-based tree once on load and cache it
 	// Apply all configuration options
 	for _, opt := range opts {
 		opt(r)

--- a/examples/cylinder_head/main.go
+++ b/examples/cylinder_head/main.go
@@ -1,0 +1,419 @@
+//-----------------------------------------------------------------------------
+/*
+
+SOURCE: https://github.com/deadsy/sdfx/tree/master/examples/cylinder_head
+
+Wallaby Cylinder Head
+
+No draft version for 3d printing and lost-PLA investment casting.
+
+*/
+//-----------------------------------------------------------------------------
+
+package main
+
+import (
+	ui "github.com/Yeicor/sdfx-ui"
+	"github.com/deadsy/sdfx/render"
+	. "github.com/deadsy/sdfx/sdf"
+	"github.com/hajimehoshi/ebiten"
+	"math"
+)
+
+//-----------------------------------------------------------------------------
+
+// overall build controls
+const casting = false // add allowances, remove machined features
+
+//-----------------------------------------------------------------------------
+// scaling
+
+const desired_scale = 1.25
+const al_shrink = 1.0 / 0.99   // ~1%
+const pla_shrink = 1.0 / 0.998 //~0.2%
+const abs_shrink = 1.0 / 0.995 //~0.5%
+
+// dimension scaling
+func dim(x float64) float64 {
+	return x * desired_scale * MillimetresPerInch * al_shrink * pla_shrink
+}
+
+var general_round = dim(0.1)
+
+//-----------------------------------------------------------------------------
+// exhaust bosses
+
+var eb_side_radius = dim(5.0 / 32.0)
+var eb_main_radius = dim(5.0 / 16.0)
+var eb_hole_radius = dim(3.0 / 16.0)
+var eb_c2c_distance = dim(13.0 / 16.0)
+var eb_distance = eb_c2c_distance / 2.0
+
+var eb_x_offset = 0.5*(head_length+eb_height) - eb_height0
+var eb_y_offset = (head_width / 2.0) - eb_distance - eb_side_radius
+var eb_z_offset = dim(1.0 / 16.0)
+
+var eb_height0 = dim(1.0 / 16.0)
+var eb_height1 = dim(1.0 / 8.0)
+var eb_height = eb_height0 + eb_height1
+
+func exhaust_boss(mode string, x_ofs float64) SDF3 {
+
+	var s0 SDF2
+
+	if mode == "body" {
+		s0 = NewFlange1(eb_distance, eb_main_radius, eb_side_radius)
+	} else if mode == "hole" {
+		s0, _ = Circle2D(eb_hole_radius)
+	} else {
+		panic("bad mode")
+	}
+
+	s1 := Extrude3D(s0, eb_height)
+	m := RotateZ(DtoR(90))
+	m = RotateY(DtoR(90)).Mul(m)
+	m = Translate3d(V3{x_ofs, eb_y_offset, eb_z_offset}).Mul(m)
+	s1 = Transform3D(s1, m)
+	return s1
+}
+
+func exhaust_bosses(mode string) SDF3 {
+	return Union3D(exhaust_boss(mode, eb_x_offset), exhaust_boss(mode, -eb_x_offset))
+}
+
+//-----------------------------------------------------------------------------
+// spark plug bosses
+
+var sp2sp_distance = dim(1.0 + (5.0 / 8.0))
+var sp_theta = DtoR(30)
+
+var sp_boss_r1 = dim(21.0 / 64.0)
+var sp_boss_r2 = dim(15.0 / 32.0)
+var sp_boss_h1 = dim(0.79)
+var sp_boss_h2 = dim(0.94)
+var sp_boss_h3 = dim(2)
+
+var sp_hole_d = dim(21.0 / 64.0)
+var sp_hole_r = sp_hole_d / 2.0
+var sp_hole_h = dim(1.0)
+
+var sp_cb_h1 = dim(1.0)
+var sp_cb_h2 = dim(2.0)
+var sp_cb_r = dim(5.0 / 16.0)
+
+var sp_hyp = sp_hole_h + sp_cb_r*math.Tan(sp_theta)
+var sp_y_ofs = sp_hyp*math.Cos(sp_theta) - head_width/2
+var sp_z_ofs = -sp_hyp * math.Sin(sp_theta)
+
+func sparkplug(mode string, x_ofs float64) SDF3 {
+	var vlist []V2
+	if mode == "boss" {
+		boss := NewPolygon()
+		boss.Add(0, 0)
+		boss.Add(sp_boss_r1, 0)
+		boss.Add(sp_boss_r1, sp_boss_h1).Smooth(sp_boss_r1*0.3, 3)
+		boss.Add(sp_boss_r2, sp_boss_h2).Smooth(sp_boss_r2*0.3, 3)
+		boss.Add(sp_boss_r2, sp_boss_h3)
+		boss.Add(0, sp_boss_h3)
+		vlist = boss.Vertices()
+	} else if mode == "hole" {
+		vlist = []V2{
+			{0, 0},
+			{sp_hole_r, 0},
+			{sp_hole_r, sp_hole_h},
+			{0, sp_hole_h},
+		}
+	} else if mode == "counterbore" {
+		p := NewPolygon()
+		p.Add(0, sp_cb_h1)
+		p.Add(sp_cb_r, sp_cb_h1).Smooth(sp_cb_r/6.0, 3)
+		p.Add(sp_cb_r, sp_cb_h2)
+		p.Add(0, sp_cb_h2)
+		vlist = p.Vertices()
+	} else {
+		panic("bad mode")
+	}
+	s0, _ := Polygon2D(vlist)
+	s, _ := Revolve3D(s0)
+	m := RotateX(Pi/2 - sp_theta)
+	m = Translate3d(V3{x_ofs, sp_y_ofs, sp_z_ofs}).Mul(m)
+	s = Transform3D(s, m)
+	return s
+}
+
+func sparkplugs(mode string) SDF3 {
+	x_ofs := 0.5 * sp2sp_distance
+	return Union3D(sparkplug(mode, x_ofs), sparkplug(mode, -x_ofs))
+}
+
+//-----------------------------------------------------------------------------
+// valve bosses
+
+var valve_diameter = dim(1.0 / 4.0)
+var valve_radius = valve_diameter / 2.0
+var valve_y_offset = dim(1.0 / 8.0)
+var valve_wall = dim(5.0 / 32.0)
+var v2v_distance = dim(1.0 / 2.0)
+var valve_draft = DtoR(5)
+
+func valve(d float64, mode string) SDF3 {
+
+	var s SDF3
+	h := head_height - cylinder_height
+
+	if mode == "boss" {
+		delta := h * math.Tan(valve_draft)
+		r1 := valve_radius + valve_wall
+		r0 := r1 + delta
+		s, _ = Cone3D(h, r0, r1, 0)
+	} else if mode == "hole" {
+		s, _ = Cylinder3D(h, valve_radius, 0)
+	} else {
+		panic("bad mode")
+	}
+
+	z_ofs := cylinder_height / 2
+	return Transform3D(s, Translate3d(V3{d, valve_y_offset, z_ofs}))
+}
+
+func valve_set(d float64, mode string) SDF3 {
+	delta := v2v_distance / 2
+	s := Union3D(valve(-delta, mode), valve(delta, mode))
+	s.(*UnionSDF3).SetMin(PolyMin(general_round))
+	return Transform3D(s, Translate3d(V3{d, 0, 0}))
+}
+
+func valve_sets(mode string) SDF3 {
+	delta := c2c_distance / 2
+	return Union3D(valve_set(-delta, mode), valve_set(delta, mode))
+}
+
+//-----------------------------------------------------------------------------
+// cylinder domes (or full base)
+
+var cylinder_height = dim(3.0 / 16.0)
+var cylinder_diameter = dim(1.0 + (1.0 / 8.0))
+var cylinder_wall = dim(1.0 / 4.0)
+var cylinder_radius = cylinder_diameter / 2.0
+
+var dome_radius = cylinder_wall + cylinder_radius
+var dome_height = cylinder_wall + cylinder_height
+var dome_draft = DtoR(5)
+
+var c2c_distance = dim(1.0 + (3.0 / 8.0))
+
+func cylinder_head(d float64, mode string) SDF3 {
+	var s SDF3
+
+	if mode == "dome" {
+		z_ofs := (head_height - dome_height) / 2
+		extra_z := general_round * 2
+		s, _ = Cylinder3D(dome_height+extra_z, dome_radius, general_round)
+		s = Transform3D(s, Translate3d(V3{d, 0, -z_ofs - extra_z}))
+	} else if mode == "chamber" {
+		z_ofs := (head_height - cylinder_height) / 2
+		s, _ = Cylinder3D(cylinder_height, cylinder_radius, 0)
+		s = Transform3D(s, Translate3d(V3{d, 0, -z_ofs}))
+	} else {
+		panic("bad mode")
+	}
+	return s
+}
+
+func cylinder_heads(mode string) SDF3 {
+	x_ofs := c2c_distance / 2
+	s := Union3D(cylinder_head(-x_ofs, mode), cylinder_head(x_ofs, mode))
+	if mode == "dome" {
+		s.(*UnionSDF3).SetMin(PolyMin(general_round))
+	}
+	return s
+}
+
+func head_base() SDF3 {
+	z_ofs := (head_height - dome_height) / 2
+	s := Extrude3D(head_wall_inner_2d(), dome_height)
+	return Transform3D(s, Translate3d(V3{0, 0, -z_ofs}))
+}
+
+//-----------------------------------------------------------------------------
+// cylinder studs: location, bosses and holes
+
+var stud_hole_radius = dim(1.0 / 16.0)
+var stud_boss_radius = dim(3.0 / 16.0)
+var stud_hole_dy = dim(11.0 / 16.0)
+var stud_hole_dx0 = dim(7.0 / 16.0)
+var stud_hole_dx1 = dim(1.066)
+
+var stud_locations = []V2{
+	{stud_hole_dx0 + stud_hole_dx1, 0},
+	{stud_hole_dx0 + stud_hole_dx1, stud_hole_dy},
+	{stud_hole_dx0 + stud_hole_dx1, -stud_hole_dy},
+	{stud_hole_dx0, stud_hole_dy},
+	{stud_hole_dx0, -stud_hole_dy},
+	{-stud_hole_dx0 - stud_hole_dx1, 0},
+	{-stud_hole_dx0 - stud_hole_dx1, stud_hole_dy},
+	{-stud_hole_dx0 - stud_hole_dx1, -stud_hole_dy},
+	{-stud_hole_dx0, stud_hole_dy},
+	{-stud_hole_dx0, -stud_hole_dy},
+}
+
+func head_stud_holes() SDF3 {
+	c, _ := Circle2D(stud_hole_radius)
+	s := Multi2D(c, stud_locations)
+	return Extrude3D(s, head_height)
+}
+
+//-----------------------------------------------------------------------------
+// head walls
+
+var head_length = dim(4.30 / 1.25)
+var head_width = dim(2.33 / 1.25)
+var head_height = dim(7.0 / 8.0)
+var head_corner_round = dim((5.0 / 32.0) / 1.25)
+var head_wall_thickness = dim(0.154)
+
+func head_wall_outer_2d() SDF2 {
+	return Box2D(V2{head_length, head_width}, head_corner_round)
+}
+
+func head_wall_inner_2d() SDF2 {
+	l := head_length - (2 * head_wall_thickness)
+	w := head_width - (2 * head_wall_thickness)
+	s0 := Box2D(V2{l, w}, 0)
+	c, _ := Circle2D(stud_boss_radius)
+	s1 := Multi2D(c, stud_locations)
+	s := Difference2D(s0, s1)
+	s.(*DifferenceSDF2).SetMax(PolyMax(general_round))
+	return s
+}
+
+func head_envelope() SDF3 {
+	s0 := Box2D(V2{head_length + 2*eb_height1, head_width}, 0)
+	return Extrude3D(s0, head_height)
+}
+
+func head_wall() SDF3 {
+	s := head_wall_outer_2d()
+	s = Difference2D(s, head_wall_inner_2d())
+	return Extrude3D(s, head_height)
+}
+
+//-----------------------------------------------------------------------------
+// manifolds
+
+var manifold_radius = dim(4.5 / 16.0)
+var manifold_hole_radius = dim(1.0 / 8.0)
+var inlet_theta = 30.2564
+var exhaust_theta = 270.0 + 13.9736
+var exhaust_x_offset = (c2c_distance / 2) + (v2v_distance / 2)
+var inlet_x_offset = (c2c_distance / 2) - (v2v_distance / 2)
+
+func manifold_set(r float64) SDF3 {
+
+	h := dim(2)
+
+	s_ex, _ := Cylinder3D(h, r, 0)
+	m := Translate3d(V3{0, 0, h / 2})
+	m = RotateX(DtoR(-90)).Mul(m)
+	m = RotateZ(DtoR(exhaust_theta)).Mul(m)
+	m = Translate3d(V3{exhaust_x_offset, valve_y_offset, eb_z_offset}).Mul(m)
+	s_ex = Transform3D(s_ex, m)
+
+	s_in, _ := Cylinder3D(h, r, 0)
+	m = Translate3d(V3{0, 0, h / 2})
+	m = RotateX(DtoR(-90)).Mul(m)
+	m = RotateZ(DtoR(inlet_theta)).Mul(m)
+	m = Translate3d(V3{inlet_x_offset, valve_y_offset, eb_z_offset}).Mul(m)
+	s_in = Transform3D(s_in, m)
+
+	return Union3D(s_ex, s_in)
+}
+
+func manifolds(mode string) SDF3 {
+	var r float64
+	if mode == "body" {
+		r = manifold_radius
+	} else if mode == "hole" {
+		r = manifold_hole_radius
+	} else {
+		panic("bad mode")
+	}
+	s0 := manifold_set(r)
+	s1 := Transform3D(s0, MirrorYZ())
+	s := Union3D(s0, s1)
+	if mode == "body" {
+		s.(*UnionSDF3).SetMin(PolyMin(general_round))
+	}
+	return s
+}
+
+//-----------------------------------------------------------------------------
+
+func allowances(s SDF3) SDF3 {
+	//eb0_2d := Slice2D(s, V3{eb_x_offset, 0, 0}, V3{1, 0, 0})
+	//return Extrude3D(eb0_2d, 10.0)
+	return nil
+}
+
+//-----------------------------------------------------------------------------
+
+func additive() SDF3 {
+	s := Union3D(
+		head_wall(),
+		//head_base(),
+		cylinder_heads("dome"),
+		valve_sets("boss"),
+		sparkplugs("boss"),
+		manifolds("body"),
+		exhaust_bosses("body"),
+	)
+	s.(*UnionSDF3).SetMin(PolyMin(general_round))
+
+	s = Difference3D(s, sparkplugs("counterbore"))
+
+	// cleanup the blending artifacts on the outside
+	s = Intersect3D(s, head_envelope())
+
+	if casting == true {
+		s = Union3D(s, allowances(s))
+	}
+
+	return s
+}
+
+//-----------------------------------------------------------------------------
+
+func subtractive() SDF3 {
+	var s SDF3
+	if casting == false {
+		s = Union3D(cylinder_heads("chamber"),
+			head_stud_holes(),
+			valve_sets("hole"),
+			sparkplugs("hole"),
+			manifolds("hole"),
+			exhaust_bosses("hole"),
+		)
+	}
+	return s
+}
+
+//-----------------------------------------------------------------------------
+
+func main() {
+	s := Difference3D(additive(), subtractive())
+
+	ebiten.SetWindowTitle("SDFX-UI cylinder head demo")
+	ebiten.SetRunnableOnUnfocused(true)
+	ebiten.SetWindowResizable(true)
+
+	// Actual rendering loop
+	err := ui.NewRenderer(s,
+		ui.OptMWatchFiles([]string{"main.go"}), // Default of "." also works, but it triggers too often if generating a profile
+		ui.Opt3Mesh(&render.MarchingCubesUniform{}, 100, math.Pi/3),
+	).Run()
+	if err != nil {
+		panic(err)
+	}
+}
+
+//-----------------------------------------------------------------------------

--- a/examples/spiral/main.go
+++ b/examples/spiral/main.go
@@ -1,3 +1,12 @@
+//-----------------------------------------------------------------------------
+/*
+
+SOURCE: https://github.com/deadsy/sdfx/blob/master/examples/spiral/main.go
+
+Spirals
+
+*/
+//-----------------------------------------------------------------------------
 package main
 
 import (
@@ -39,11 +48,11 @@ func spiralSdf() (s interface{}, err error) {
 	//s = sdf.Difference2D(s.(sdf.SDF2), t)
 
 	//s = sdf.Extrude3D(s.(sdf.SDF2), 4)
-	s, _ = sdf.ExtrudeRounded3D(s.(sdf.SDF2), 4, 0.25)
+	//s, _ = sdf.ExtrudeRounded3D(s.(sdf.SDF2), 4, 0.25)
 	//s, _ = sdf.RevolveTheta3D(s.(sdf.SDF2), math.Pi/2)
 
-	//box3, _ := sdf.Box3D(sdf.V3{X: 20, Y: 10, Z: 5}, 0.2)
-	//box3 = sdf.Transform3D(box3, sdf.Translate3d(sdf.V3{Z: 15}))
+	//box3, _ := sdf.Box3D(sdf.V3{X: 40, Y: 10, Z: 15}, 0.2)
+	//box3 = sdf.Transform3D(box3, sdf.Translate3d(sdf.V3{Y: 30, Z: -5}))
 	//s = sdf.Union3D(s.(sdf.SDF3), box3)
 
 	return s, err
@@ -83,7 +92,7 @@ func main() {
 	// Actual rendering loop
 	err = ui.NewRenderer(s,
 		ui.OptMWatchFiles([]string{"main.go"}), // Default of "." also works, but it triggers too often if generating a profile
-		//ui.Opt3Mesh(&render.MarchingCubesUniform{}, 200, math.Pi/3),
+		//ui.Opt3Mesh(&render.MarchingCubesUniform{}, 100, math.Pi/3),
 	).Run()
 	if err != nil {
 		panic(err)

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/fogleman/fauxgl v0.0.0-20200818143847-27cddc103802
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/hajimehoshi/ebiten v1.12.12
+	github.com/mitchellh/reflectwalk v1.0.2
 	github.com/subchen/go-trylock/v2 v2.0.0
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 )
@@ -20,7 +21,6 @@ require (
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/llgcode/draw2d v0.0.0-20210904075650-80aa0a2a901d // indirect
 	github.com/yofu/dxf v0.0.0-20190710012328-5a6d1e83f16c // indirect
-	golang.org/x/exp v0.0.0-20191002040644-a1355ae1e2c3 // indirect
 	golang.org/x/exp/shiny v0.0.0-20220212023102-3e31098684e2 // indirect
 	golang.org/x/mobile v0.0.0-20220112015953-858099ff7816 // indirect
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,7 +5,6 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/ajstarks/deck v0.0.0-20200831202436-30c9fc6549a9/go.mod h1:JynElWSGnm/4RlzPXRlREEwqTHAN3T56Bv2ITsFT3gY=
 github.com/ajstarks/deck/generate v0.0.0-20210309230005-c3f852c02e19/go.mod h1:T13YZdzov6OU0A1+RfKZiZN9ca6VeKdBdyDV+BY97Tk=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
-github.com/ajstarks/svgo v0.0.0-20200725142600-7a3c8b57fecb h1:EVl3FJLQCzSbgBezKo/1A4ADnJ4mtJZ0RvnNzDJ44nY=
 github.com/ajstarks/svgo v0.0.0-20200725142600-7a3c8b57fecb/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b h1:slYM766cy2nI3BwyRiyQj/Ud48djTMtMebDqepE95rw=
 github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b/go.mod h1:1KcenG0jGWcpt8ov532z81sp/kMMUG485J2InIOyADM=
@@ -16,8 +15,6 @@ github.com/cenkalti/backoff/v4 v4.1.2 h1:6Yo7N8UP2K6LWZnW94DLVSSrbobcWdVzAYOisuD
 github.com/cenkalti/backoff/v4 v4.1.2/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deadsy/sdfx v0.0.0-20220109181759-3687bff02ea7 h1:3L0NJZJamn8QeaWeHIxGS3bbcd7c+DC1DxIvmIa3AYM=
-github.com/deadsy/sdfx v0.0.0-20220109181759-3687bff02ea7/go.mod h1:bjsFZRp7zdb9m29hIDXPN/V5H/AkjJ1AIr5iBuj7FcI=
 github.com/deadsy/sdfx v0.0.0-20220211044058-15587d44f9eb h1:HtE08BPEWyvaWo4xZP2Z3MpSD4gi1yS7y5IzHCMoiw4=
 github.com/deadsy/sdfx v0.0.0-20220211044058-15587d44f9eb/go.mod h1:bjsFZRp7zdb9m29hIDXPN/V5H/AkjJ1AIr5iBuj7FcI=
 github.com/dhconnelly/rtreego v1.1.0/go.mod h1:SDozu0Fjy17XH1svEXJgdYq8Tah6Zjfa/4Q33Z80+KM=
@@ -35,9 +32,7 @@ github.com/go-fonts/liberation v0.1.1/go.mod h1:K6qoJYypsmfVjWg8KOVDQhLc8UDgIK2H
 github.com/go-fonts/stix v0.1.0/go.mod h1:w/c1f0ldAUlJmLBvlbkvVXLAD+tAMqobIIQpmnUIzUY=
 github.com/go-gl/gl v0.0.0-20180407155706-68e253793080/go.mod h1:482civXOzJJCPzJ4ZOX/pwvXBWSnzD4OKMdH4ClKGbk=
 github.com/go-gl/glfw v0.0.0-20180426074136-46a8d530c326/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
-github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1 h1:QbL/5oDUmRBzO9/Z7Seo6zf912W/a6Sr4Eu0G/3Jho0=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
-github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200707082815-5321531c36a2 h1:Ac1OEHHkbAZ6EUnJahF0GKcU0FjPc/V8F1DvjhKngFE=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200707082815-5321531c36a2/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20211213063430-748e38ca8aec h1:3FLiRYO6PlQFDpUU7OEFlWgjGD1jnBIVSJ5SYRWk+9c=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20211213063430-748e38ca8aec/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -63,12 +58,13 @@ github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/llgcode/draw2d v0.0.0-20200930101115-bfaf5d914d1e h1:YRRazju3DMGuZTSWEj0nE2SCRcK3DW/qdHQ4UQx7sgs=
 github.com/llgcode/draw2d v0.0.0-20200930101115-bfaf5d914d1e/go.mod h1:mVa0dA29Db2S4LVqDYLlsePDzRJLDfdhVZiI15uY0FA=
 github.com/llgcode/draw2d v0.0.0-20210904075650-80aa0a2a901d h1:4/ycg+VrwjGurTqiHv2xM/h6Qm81qSra+KbfT4FH2FA=
 github.com/llgcode/draw2d v0.0.0-20210904075650-80aa0a2a901d/go.mod h1:mVa0dA29Db2S4LVqDYLlsePDzRJLDfdhVZiI15uY0FA=
 github.com/llgcode/ps v0.0.0-20150911083025-f1443b32eedb h1:61ndUreYSlWFeCY44JxDDkngVoI7/1MVhEl98Nm0KOk=
 github.com/llgcode/ps v0.0.0-20150911083025-f1443b32eedb/go.mod h1:1l8ky+Ew27CMX29uG+a2hNOKpeNYEQjjtiALiBlFQbY=
+github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
+github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/phpdave11/gofpdf v1.4.2/go.mod h1:zpO6xFn9yxo3YLyMvW8HcKWVdbNqgIfOOp2dXMnm1mY=
 github.com/phpdave11/gofpdi v1.0.12/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
@@ -97,7 +93,6 @@ golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190731235908-ec7cb31e5a56/go.mod h1:JhuoJpWY28nO4Vef9tZUw9qufEGTyX1+7lmHxV5q5G4=
-golang.org/x/exp v0.0.0-20191002040644-a1355ae1e2c3 h1:n9HxLrNxWWtEb1cA950nuEEj3QnKbtsCJ6KjcgisNUs=
 golang.org/x/exp v0.0.0-20191002040644-a1355ae1e2c3/go.mod h1:NOZ3BPKG0ec/BKJQgnvsSFpcKLM5xXVWnvZS97DWHgE=
 golang.org/x/exp/shiny v0.0.0-20220212023102-3e31098684e2 h1:Hn6jvT4ZwvNT9qjojs0x+SPSqDL8M7diAfiNGSsW/fA=
 golang.org/x/exp/shiny v0.0.0-20220212023102-3e31098684e2/go.mod h1:NtXcNtv5Wu0zUbBl574y/D5MMZvnQnV3sgjZxbs64Jo=
@@ -117,7 +112,6 @@ golang.org/x/image v0.0.0-20211028202545-6944b10bf410/go.mod h1:023OzeP/+EPmXeap
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190415191353-3e0bab5405d6/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
-golang.org/x/mobile v0.0.0-20210208171126-f462b3930c8f h1:aEcjdTsycgPqO/caTgnxfR9xwWOltP/21vtJyFztEy0=
 golang.org/x/mobile v0.0.0-20210208171126-f462b3930c8f/go.mod h1:skQtrUTUwhdJvXM/2KKJzY8pDgNr9I/FOMqDVRPBUS4=
 golang.org/x/mobile v0.0.0-20220112015953-858099ff7816 h1:jhDgkcu3yQ4tasBZ+1YwDmK7eFmuVf1w1k+NGGGxfmE=
 golang.org/x/mobile v0.0.0-20220112015953-858099ff7816/go.mod h1:pe2sM7Uk+2Su1y7u/6Z8KJ24D7lepUjFZbhFOrmDfuQ=
@@ -149,8 +143,6 @@ golang.org/x/sys v0.0.0-20210304124612-50617c2ba197/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 h1:id054HUawV2/6IGm2IV8KZQjqtwAOo2CYlOToYqa0d0=
-golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158 h1:rm+CHSpPEEW2IsXUib1ThaHIjuBVZjxNgSKmBLFfD4c=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/impl2_test.go
+++ b/impl2_test.go
@@ -13,7 +13,7 @@ func BenchmarkDevRenderer2_Render(b *testing.B) {
 	s, _ := sdf.ArcSpiral2D(1.0, 20.0, 0.25*sdf.Pi, 8*sdf.Tau, 1.0)
 	impl := newDevRenderer2(s)
 	b.ReportAllocs()
-	state := RendererState{
+	state := internal.RendererState{
 		ResInv: 8,
 		Bb:     s.BoundingBox(),
 	}

--- a/impl3_test.go
+++ b/impl3_test.go
@@ -15,7 +15,7 @@ func BenchmarkDevRenderer3_Render(b *testing.B) {
 	s3, _ := sdf.ExtrudeRounded3D(s, 4, 1)
 	impl := newDevRenderer3(s3)
 	b.ReportAllocs()
-	state := RendererState{
+	state := internal.RendererState{
 		ResInv: 8,
 		Bb:     s.BoundingBox(),
 	}

--- a/interaction.go
+++ b/interaction.go
@@ -226,7 +226,7 @@ func (r *Renderer) drawUI(screen *ebiten.Image) {
 	// Draw current state and controls
 	r.implStateLock.RLock()
 	defer r.implStateLock.RUnlock()
-	msgFmt := "TPS: %0.2f/%d\nResolution: %.2f [+/-]\nColor: %d [C]\nBboxes: %t [B, unimpl]\nReset camera [R]"
+	msgFmt := "TPS: %0.2f/%d\nResolution: %.2f [+/-]\nColor: %d [C]\nBoxes: %t [B]\nReset camera [R]"
 	msgValues := []interface{}{ebiten.CurrentTPS(), ebiten.MaxTPS(), 1 / float64(r.implState.ResInv), r.implState.ColorMode, r.implState.DrawBbs}
 	switch r.implDimCache {
 	case 2:

--- a/internal/reflect.go
+++ b/internal/reflect.go
@@ -1,0 +1,174 @@
+package internal
+
+import (
+	"bytes"
+	"encoding/gob"
+	"github.com/deadsy/sdfx/sdf"
+	"github.com/mitchellh/reflectwalk"
+	"reflect"
+	"unsafe"
+)
+
+// ReflectionSDF provides reflect-based metadata about the SDF hierarchy with the provided root: bounding boxes, etc.
+// Remember that reflect is relatively slow and results should be cached.
+type ReflectionSDF struct {
+	sdf interface{}
+}
+
+// NewReflectionSDF is internal: do not use outside this project
+func NewReflectionSDF(sdf interface{}) *ReflectionSDF {
+	return &ReflectionSDF{sdf: sdf}
+}
+
+type ReflectTree struct {
+	Info     *SDFNodeMeta
+	Children []*ReflectTree
+}
+
+func (r *ReflectionSDF) GetReflectTree(targetTypes ...reflect.Type) *ReflectTree {
+	return r.getReflectTree(r.sdf, targetTypes...)
+}
+
+func (r *ReflectionSDF) getReflectTree(rootSdf interface{}, targetSdfTypes ...reflect.Type) *ReflectTree {
+	var res *ReflectTree
+	parentToSubRes := map[interface{}]*ReflectTree{}
+	uniqueID := 0
+	err := reflectwalk.Walk([]interface{}{rootSdf}, /* <-- Wrapper for root to work */
+		newTreeSDF2WalkerFunc(func(parents []*SDFNodeMeta, value *SDFNodeMeta) error {
+			// Process the full hierarchy
+			value.ID = uniqueID
+			uniqueID++
+			subTree := &ReflectTree{Info: value, Children: []*ReflectTree{}}
+			if len(parents) == 0 { // Single root node
+				res = subTree
+			} else { // Some child
+				parentToRegisterTo := parents[len(parents)-1].SDF
+				appendTo := parentToSubRes[parentToRegisterTo]
+				appendTo.Children = append(appendTo.Children, subTree)
+			}
+			parentToSubRes[value.SDF] = subTree
+			return nil
+		}, targetSdfTypes...))
+	if err != nil {
+		panic(err) // Shouldn't happen
+	}
+	return res
+}
+
+type SDFNodeMeta struct {
+	ID    int      // An unique ID for this node (unique for the current tree)
+	Level int      // The fake level (it is not consistent across different branches)
+	Bb    sdf.Box3 // The cached bounding box (as it can be sent through the network)
+	// The following are only available in main renderer mode (can't be sent through the network and needs a code restart to use)
+	SDF   interface{}   // The SDF (2D/3D)
+	Value reflect.Value // The Value (can be modified!)
+}
+
+func init() {
+	gob.Register(sdf.Box3{})
+}
+
+func (s *SDFNodeMeta) GobEncode() ([]byte, error) {
+	buf := &bytes.Buffer{}
+	err := gob.NewEncoder(buf).Encode([]interface{}{s.ID, s.Level, s.Bb})
+	return buf.Bytes(), err
+}
+
+func (s *SDFNodeMeta) GobDecode(bs []byte) error {
+	var tmp []interface{}
+	err := gob.NewDecoder(bytes.NewReader(bs)).Decode(&tmp)
+	if err != nil {
+		return nil
+	}
+	s.ID = tmp[0].(int)
+	s.SDF = tmp[1]
+	s.Bb = tmp[2].(sdf.Box3)
+	return err
+}
+
+type treeSDFWalkerFunc struct {
+	impl                        func(parents []*SDFNodeMeta, value *SDFNodeMeta) error
+	targetSdfTypes              []reflect.Type
+	curParents                  []*SDFNodeMeta
+	lastFound                   *SDFNodeMeta
+	curLevel, minLevelSinceLast int
+}
+
+func newTreeSDF2WalkerFunc(impl func(parents []*SDFNodeMeta, value *SDFNodeMeta) error, targetSdfTypes ...reflect.Type) *treeSDFWalkerFunc {
+	return &treeSDFWalkerFunc{impl: impl, targetSdfTypes: targetSdfTypes}
+}
+
+func (i *treeSDFWalkerFunc) Enter(_ reflectwalk.Location) error {
+	i.curLevel++
+	return nil
+}
+
+func (i *treeSDFWalkerFunc) Exit(_ reflectwalk.Location) error {
+	i.curLevel--
+	if i.curLevel < i.minLevelSinceLast {
+		i.minLevelSinceLast = i.curLevel
+	}
+	return nil
+}
+
+func (i *treeSDFWalkerFunc) Interface(value reflect.Value) error {
+	// FIXME: Assumes all SDF2 are always saved as interfaces (but they could be concrete types: pointers, functions, maps, etc.)
+	if !value.CanInterface() {
+		// HACK: Read-only access to unexported value (Interface() is not allowed due to possible write operations?)
+		value = getUnexportedField(value, unsafe.Pointer(value.UnsafeAddr()))
+	}
+	value = value.Elem() // The internal element of the interface
+	for _, tp := range i.targetSdfTypes {
+		if value.Type().Implements(tp) {
+			return i.handleSDF(value, value.Interface())
+		}
+	}
+	return nil
+}
+
+func (i *treeSDFWalkerFunc) handleSDF(value reflect.Value, s interface{}) error {
+	// FIXME: Detect and avoid infinite loops (self-references in hierarchy)
+	//log.Println("handleSDF:", value.Type(), i.curLevel)
+
+	// Find out which SDF to assign to this SDF2
+	if i.lastFound != nil && i.curLevel > i.lastFound.Level && i.minLevelSinceLast > i.lastFound.Level { // Below in hierarchy
+		i.curParents = append(i.curParents, i.lastFound)
+	} else {
+		isAbove := false
+		for len(i.curParents) > 0 && i.curLevel <= i.curParents[len(i.curParents)-1].Level { // Above in hierarchy
+			isAbove = true
+			i.curParents = i.curParents[:len(i.curParents)-1]
+		}
+		if !isAbove { // At the same Level
+			// Nothing to change
+		}
+	}
+
+	// Extra cached values
+	var bb sdf.Box3
+	switch tmp := s.(type) {
+	case sdf.SDF2:
+		bb = sdf.Box3{Min: tmp.BoundingBox().Min.ToV3(-1e-3), Max: tmp.BoundingBox().Max.ToV3(1e-3)}
+	case sdf.SDF3:
+		bb = tmp.BoundingBox()
+	}
+
+	// Record the last found Level and reset minLevelSinceLast
+	i.lastFound = &SDFNodeMeta{
+		ID:    -1,
+		Level: i.curLevel,
+		Bb:    bb,
+		SDF:   s,
+		Value: value,
+	}
+	i.minLevelSinceLast = i.curLevel + 1 // Will be reset on next iteration to curLevel if going back up the tree
+
+	// Call the implementation
+	err := i.impl(i.curParents, i.lastFound)
+
+	return err
+}
+
+func getUnexportedField(field reflect.Value, unsafeAddr unsafe.Pointer) reflect.Value {
+	return reflect.NewAt(field.Type(), unsafeAddr).Elem()
+}

--- a/internal/reflect2.go
+++ b/internal/reflect2.go
@@ -1,0 +1,52 @@
+package internal
+
+import (
+	"github.com/deadsy/sdfx/sdf"
+	"reflect"
+)
+
+var sdf2Type = reflect.TypeOf((*sdf.SDF2)(nil)).Elem()
+
+func (r *ReflectionSDF) GetReflectSDFTree2() *ReflectTree {
+	return r.GetReflectTree(sdf2Type)
+}
+
+func (r *ReflectTree) GetBoundingBoxes2() []sdf.Box2 {
+	return r.getBoundingBoxes2(r)
+}
+
+// getBoundingBoxes2 flattens the tree if only bounds are wanted
+func (r *ReflectTree) getBoundingBoxes2(tree *ReflectTree) []sdf.Box2 {
+	var res []sdf.Box2
+	// HACK: Skip condition: to make results cleaner
+	skipParent := false
+	// HACK: Stop condition (apart from finishing the tree): to make results cleaner
+	skipChildren := false
+	if !tree.Info.Value.IsNil() {
+		tpName := tree.Info.Value.Type().String()
+		switch tpName {
+		//case "*ui.swapYZ":
+		//	fallthrough
+		//case "*ui.invertZ":
+		//	skipParent = true
+		case "*sdf.TransformSDF2":
+			fallthrough
+		case "*sdf.ScaleUniformSDF2":
+			skipChildren = true
+		default:
+		}
+	}
+	if //goland:noinspection GoBoolExpressions
+	!skipParent {
+		res = append(res, sdf.Box2{
+			Min: sdf.V2{X: tree.Info.Bb.Min.X, Y: tree.Info.Bb.Min.Y},
+			Max: sdf.V2{X: tree.Info.Bb.Max.X, Y: tree.Info.Bb.Max.Y},
+		})
+	}
+	if !skipChildren {
+		for _, subTree := range tree.Children {
+			res = append(res, r.getBoundingBoxes2(subTree)...)
+		}
+	}
+	return res
+}

--- a/internal/reflect3.go
+++ b/internal/reflect3.go
@@ -1,0 +1,50 @@
+package internal
+
+import (
+	"github.com/deadsy/sdfx/sdf"
+	"reflect"
+)
+
+var sdf3Type = reflect.TypeOf((*sdf.SDF3)(nil)).Elem()
+
+func (r *ReflectionSDF) GetReflectSDFTree3() *ReflectTree {
+	// NOTE: The SDF3 hierarchy may also contain SDF2 (most likely for initial 2D design that is later extruded)
+	// TODO: Include SDF2 boxes? Works, but results in ugly renderings
+	return r.GetReflectTree( /*sdf2Type, */ sdf3Type)
+}
+
+func (r *ReflectTree) GetBoundingBoxes3() []sdf.Box3 {
+	return r.getBoundingBoxes3(r)
+}
+
+// getBoundingBoxes3 flattens the tree if only bounds are wanted
+func (r *ReflectTree) getBoundingBoxes3(tree *ReflectTree) []sdf.Box3 {
+	var res []sdf.Box3
+	// HACK: Skip condition: to make results cleaner
+	skipParent := false
+	// HACK: Stop condition (apart from finishing the tree): to make results cleaner
+	skipChildren := false
+	if !tree.Info.Value.IsNil() {
+		tpName := tree.Info.Value.Type().String()
+		switch tpName {
+		case "*ui.swapYZ":
+			fallthrough
+		case "*ui.invertZ":
+			skipParent = true
+		case "*sdf.TransformSDF3":
+			fallthrough
+		case "*sdf.ScaleUniformSDF3":
+			skipChildren = true
+		default:
+		}
+	}
+	if !skipParent {
+		res = append(res, tree.Info.Bb)
+	}
+	if !skipChildren {
+		for _, subTree := range tree.Children {
+			res = append(res, r.getBoundingBoxes3(subTree)...)
+		}
+	}
+	return res
+}

--- a/internal/reflect_test.go
+++ b/internal/reflect_test.go
@@ -1,0 +1,55 @@
+package internal
+
+import (
+	"fmt"
+	"github.com/deadsy/sdfx/sdf"
+	"strings"
+	"testing"
+)
+
+func preOrderNumSDFs(tree *ReflectTree, pre []int, level int) []int {
+	pre = append(pre, len(tree.Children))
+	fmt.Printf("%s> %#v\n", strings.Repeat("  ", level), tree.Info.SDF)
+	for _, ch := range tree.Children {
+		pre = preOrderNumSDFs(ch, pre, level+1)
+	}
+	return pre
+}
+
+func testTree2Common(t *testing.T, d sdf.SDF2, expectedPreOrderNumSDFs []int) {
+	tree := NewReflectionSDF(d).GetReflectSDFTree2()
+	gotPreOrderNumSDFs := preOrderNumSDFs(tree, []int{}, 0)
+	if len(expectedPreOrderNumSDFs) != len(gotPreOrderNumSDFs) {
+		t.Fatalf("expected a total of %d nodes in the reflection tree, but got %d",
+			len(expectedPreOrderNumSDFs), len(gotPreOrderNumSDFs)) // Count the root node
+	}
+	for step, expected := range expectedPreOrderNumSDFs {
+		got := gotPreOrderNumSDFs[step]
+		if expected != got {
+			t.Fatalf("expected %d children SDFs at pre-order step %d, but got %d", expected, step, got)
+		}
+	}
+}
+
+func TestReflectTree2Single(t *testing.T) {
+	s := sdf.Box2D(sdf.V2{X: 1, Y: 1}, 0.25)
+	testTree2Common(t, s, []int{0})
+}
+
+func TestReflectTree2Union(t *testing.T) {
+	var s sdf.SDF2
+	s = sdf.Box2D(sdf.V2{X: 1, Y: 1}, 0.25)
+	s2 := sdf.Box2D(sdf.V2{X: 2, Y: 1}, 0.25)
+	s = sdf.Union2D(s, s2)
+	testTree2Common(t, s, []int{2, 0, 0})
+}
+
+func TestReflectTree2MultiLevel(t *testing.T) {
+	var s sdf.SDF2
+	s = sdf.Box2D(sdf.V2{X: 1, Y: 1}, 0.25)
+	s2 := sdf.Box2D(sdf.V2{X: 2, Y: 1}, 0.25)
+	s = sdf.Union2D(s, s2)
+	s2 = sdf.Box2D(sdf.V2{X: 1, Y: 2}, 0.25)
+	s = sdf.Difference2D(s, s2)
+	testTree2Common(t, s, []int{2, 2, 0, 0, 0})
+}

--- a/internal/state.go
+++ b/internal/state.go
@@ -14,6 +14,8 @@ type DevRendererImpl interface {
 	Dimensions() int
 	// BoundingBox returns the full bounding box of the surface (Z is ignored for SDF2)
 	BoundingBox() sdf.Box3
+	// ReflectTree returns the main reflection-based metadata structure for handling the SDF hierarchy
+	ReflectTree() *ReflectTree
 	// ColorModes returns the number of color modes supported
 	ColorModes() int
 	// Render performs a full render, given the screen size (it may be cancelled using the given context).
@@ -25,9 +27,10 @@ type DevRendererImpl interface {
 // RendererState is an internal struct that has to be exported for RPC.
 type RendererState struct {
 	// SHARED
-	ResInv    int  // How detailed is the image: number screen pixels for each pixel rendered (SDF2: use a power of two)
-	DrawBbs   bool // Whether to show all bounding boxes (useful for debugging subtraction/intersection of SDFs)
-	ColorMode int  // The color mode (each render may support multiple modes)
+	ResInv      int          // How detailed is the image: number screen pixels for each pixel rendered (SDF2: use a power of two)
+	DrawBbs     bool         // Whether to show all bounding boxes (useful for debugging subtraction/intersection of SDFs)
+	ColorMode   int          // The color mode (each render may support multiple modes)
+	ReflectTree *ReflectTree // Cached read-only reflection metadata to have some insight into the SDF hierarchy
 	// SDF2
 	Bb sdf.Box2 // Controls the scale and displacement
 	// SDF3


### PR DESCRIPTION
The main contribution consists of adding a ReflectionTree, which provides access to the SDF hierarchy usually hidden to users. This will be useful for useful work like selecting a sub-SDF with the mouse.

It also implements the rendering of 2D and 3D bounding boxes, using the ReflectionTree as the source of information.

# Demos
![Screenshot_20220226_211649](https://user-images.githubusercontent.com/4929005/155857839-16e01ccf-6e32-4539-8ace-9a3a01e10074.png)

![Screenshot_20220226_210052](https://user-images.githubusercontent.com/4929005/155857774-9d3d8d19-d2a7-408e-b107-9a95d5628a71.png)

![Screenshot_20220226_205856](https://user-images.githubusercontent.com/4929005/155857780-89552844-6021-4cfb-aff7-9ce53461c34f.png)

